### PR TITLE
Simplify build logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,29 +1,7 @@
-import com.github.benmanes.gradle.versions.VersionsPlugin
-import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.palantir.gradle.docker.DockerExtension
-import com.palantir.gradle.docker.PalantirDockerPlugin
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.plugins.ide.idea.model.IdeaLanguageLevel
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-buildscript {
-    val versionPluginVer = "0.20.0"
-    val shadowPluginVer = "2.0.4"
-    val dockerPluginVer = "0.20.1"
-
-    repositories {
-        jcenter()
-        maven { setUrl("https://plugins.gradle.org/m2/") }
-    }
-
-    dependencies {
-        classpath("com.github.jengelman.gradle.plugins:shadow:$shadowPluginVer")
-        // gradle dependencyUpdates -Drevision=release
-        classpath("com.github.ben-manes:gradle-versions-plugin:$versionPluginVer")
-        classpath("gradle.plugin.com.palantir.gradle.docker:gradle-docker:$dockerPluginVer")
-    }
-}
 
 val kotlinLoggingVer = "1.6.10"
 val logbackVer = "1.2.3"
@@ -33,14 +11,11 @@ val junitJupiterVer = "5.3.1"
 
 plugins {
     application
-    idea
     kotlin("jvm") version "1.2.70"
-}
-
-apply {
-    apply<ShadowPlugin>()
-    apply<PalantirDockerPlugin>()
-    apply<VersionsPlugin>()
+    id("com.github.johnrengelman.shadow") version "2.0.4"
+    id("com.github.ben-manes.versions") version "0.20.0"
+    id("com.palantir.docker") version "0.20.1"
+    idea
 }
 
 repositories {
@@ -48,15 +23,15 @@ repositories {
 }
 
 dependencies {
-    compile(kotlin("stdlib-jdk8"))
-    compile(kotlin("reflect"))
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
 
-    compile("io.github.microutils:kotlin-logging:$kotlinLoggingVer")
+    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVer")
 
-    compile("org.slf4j:slf4j-api:$slf4jVer")
+    implementation("org.slf4j:slf4j-api:$slf4jVer")
     runtime("ch.qos.logback:logback-classic:$logbackVer")
 
-    testCompile(kotlin("test-junit5"))
+    testImplementation(kotlin("test-junit5"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVer")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVer")
 }
@@ -117,7 +92,7 @@ tasks {
         dependsOn(shadowJar)
     }
 
-    configure<DockerExtension> {
+    docker {
         dependsOn(build)
         name = "${project.group}/${shadowJar.baseName}"
         files(shadowJar.outputs)


### PR DESCRIPTION
A few changes to make the build script simpler:
- prefer the `plugins {}` block to apply plugins
- configure the `docker` extension using the generated accessors thanks to the `plugins {}` block
- prefer non-deprecated configurations for dependencies